### PR TITLE
fix: Do not trigger workflows on `pull_request_target` trigger

### DIFF
--- a/.github/workflows/draft-image-release.yml
+++ b/.github/workflows/draft-image-release.yml
@@ -5,8 +5,7 @@ on:
     # branches to consider in the event; optional, defaults to all
     branches:
       - main
-  # pull_request_target event is required for autolabeler to support PRs from forks
-  pull_request_target:
+  pull_request:
     # Only following types are handled by the action, but one can default to all as well
     types: [opened, reopened, synchronize]
 

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,7 +1,7 @@
 name: "Lint PR"
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited


### PR DESCRIPTION
# Description
<!-- Describe: (1) what you are doing and (2) why you are doing it -->
Security recommendations say you should not [trigger workflows on `pull_request_target` trigger](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/). Using such trigger may lead to repository compromise.

# Checklist
Mandatory:
- [x] PR title is suitable to be included in the release notes

If applicable:
- [ ] Changes have been documented
- [ ] Changes have been manually tested
- [ ] New tests has been added
