### PR TITLE
ci: Add `CODEOWNERS` file in preparation for making the repo public

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in the repo.
+# Unless a later match takes precedence, global owners will be requested
+# for review when someone opens a pull request.
+*       @juanjjaramillo


### PR DESCRIPTION
# Description
<!-- Describe: (1) what you are doing and (2) why you are doing it -->
As part of making the repo public to continue testing more advanced GitHub features that are not available in private repos, we add a `CODEOWNERS` file to make sure all pull requests are approved by the global owner

# Checklist
Mandatory:
- [x] PR title is suitable to be included in the release notes

If applicable:
- [ ] Changes have been documented
- [ ] Changes have been manually tested
- [ ] New tests has been added
