### PR TITLE
ci: Improve 'Draft Image Release' workflow

### DIFF
--- a/.github/draft-image-release-config.yml
+++ b/.github/draft-image-release-config.yml
@@ -8,6 +8,8 @@ categories:
     label: 'Type/feat'
   - title: '🐛 Bug Fixes'
     label: 'Type/fix'
+  - title: '📝 Other'
+    label: 'Type/other'
 exclude-labels:
   - 'Type/skip'
 
@@ -21,7 +23,7 @@ autolabeler:
   - label: 'Type/fix'
     title:
       - '/^fix/i'
-  - label: 'Type/skip'
+  - label: 'Type/other'
     title:
       - '/^(build|chore|ci|docs|perf|refactor|revert|style|test)/i'
 
@@ -32,8 +34,8 @@ change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&'
 replacers:
   # Remove conventional commit prefix
-  - search: '/[a-zA-Z]+(\([a-zA-Z]+\))?!?:\s*/'
-    replace: ''
+  - search: '/^- [a-zA-Z]+(\([a-zA-Z]+\))?!?:\s*/gm'
+    replace: '- '
 
 version-resolver:
   major:

--- a/.github/workflows/draft-image-release.yml
+++ b/.github/workflows/draft-image-release.yml
@@ -5,8 +5,8 @@ on:
     # branches to consider in the event; optional, defaults to all
     branches:
       - main
+  # pull_request event is required only for autolabeler
   pull_request:
-    # Only following types are handled by the action, but one can default to all as well
     types: [opened, reopened, edited, synchronize]
 
 permissions:
@@ -23,6 +23,18 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
+      # Command `gh pr edit` needs to run in a repository,
+      # so fetch a single file to make next step succeed
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            README.md
+          sparse-checkout-cone-mode: false
+      - name: Remove labels in preparation for autolabeler
+        if: github.event_name == 'pull_request'
+        run: gh pr edit ${{ github.event.number }} --remove-label "Type/break,Type/feat,Type/fix,Type/other"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # Drafts your next Release notes as Pull Requests are merged into "main"
       - uses: release-drafter/release-drafter@v5
         id: draft-image-release


### PR DESCRIPTION
# Description
<!-- Describe: (1) what you are doing and (2) why you are doing it -->
- Instead of ignoring PRs, bundle them in a new category
- Remove previous labels before autolabeler runs to account for PR title changes

# Checklist
Mandatory:
- [x] PR title is suitable to be included in the release notes

If applicable:
- [x] Changes have been documented
- [x] Changes have been manually tested
- [ ] New tests has been added
