### PR TITLE
ci: Fix 'Publish Release' workflow

### DIFF
--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -41,9 +41,12 @@ jobs:
           fi
 
       - name: Install Helm Docs
+        # Use syntax ${version} instead of $version
+        # In certain contexts, only the less ambiguous ${version} form works
+        # Source: https://tldp.org/LDP/abs/html/parameter-substitution.html
         run: |
           version="1.11.0"
-          wget https://github.com/norwoodj/helm-docs/releases/download/v$version/helm-docs_$version_Linux_x86_64.tar.gz
+          wget https://github.com/norwoodj/helm-docs/releases/download/v${version}/helm-docs_${version}_Linux_x86_64.tar.gz
           tar --extract --verbose --file helm-docs_$version_Linux_x86_64.tar.gz
           sudo mv helm-docs /usr/local/sbin
 


### PR DESCRIPTION
# Description
<!-- Describe: (1) what you are doing and (2) why you are doing it -->
Use syntax "${version}" instead of "$version". In certain contexts, only the less ambiguous "${version}" form works. [Source](https://tldp.org/LDP/abs/html/parameter-substitution.html).

# Checklist
Mandatory:
- [x] PR title is suitable to be included in the release notes

If applicable:
- [x] Changes have been documented
- [x] Changes have been manually tested
- [ ] New tests has been added
