### PR TITLE
ci: Allow for release PR to automerge

### DIFF
--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -81,7 +81,7 @@ jobs:
             --title "ci: Bump Helm chart versions" \
             --body "Update Helm chart versions to reflect the newly-published release"
           gh pr merge \
-            --auto \
+            --admin \
             --body "Automatically merged by github-actions" \
             --delete-branch \
             --squash

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.dll
 *.so
 *.dylib
+helm-docs
 
 # Test binary, built with `go test -c`
 *.test


### PR DESCRIPTION
# Description
<!-- Describe: (1) what you are doing and (2) why you are doing it -->
Allow the PR bumping versions on Helm charts to automerge

# Checklist
Mandatory:
- [x] PR title is suitable to be included in the release notes

If applicable:
- [ ] Changes have been documented
- [ ] Changes have been manually tested
- [ ] New tests has been added
