### PR TITLE
ci: Improve 'Draft Image Release' to allow simultaneous releases of Helm charts

### DIFF
--- a/.github/draft-image-release-config.yml
+++ b/.github/draft-image-release-config.yml
@@ -1,29 +1,32 @@
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
+# A known prefix used to filter release tags. For matching tags,
+# this prefix is stripped before attempting to parse the version
+tag-prefix: 'v'
 
 categories:
   - title: '💥 Breaking Changes'
-    label: 'Type/break'
+    label: 'Release/break'
   - title: '🚀 Features'
-    label: 'Type/feat'
+    label: 'Release/feat'
   - title: '🐛 Bug Fixes'
-    label: 'Type/fix'
+    label: 'Release/fix'
   - title: '📝 Other'
-    label: 'Type/other'
+    label: 'Release/other'
 exclude-labels:
-  - 'Type/skip'
+  - 'Release/skip'
 
 autolabeler:
-  - label: 'Type/break'
+  - label: 'Release/break'
     title:
       - '/!:/'
-  - label: 'Type/feat'
+  - label: 'Release/feat'
     title:
       - '/^feat/i'
-  - label: 'Type/fix'
+  - label: 'Release/fix'
     title:
       - '/^fix/i'
-  - label: 'Type/other'
+  - label: 'Release/other'
     title:
       - '/^(build|chore|ci|docs|perf|refactor|revert|style|test)/i'
 
@@ -40,13 +43,13 @@ replacers:
 version-resolver:
   major:
     labels:
-      - 'Type/break'
+      - 'Release/break'
   minor:
     labels:
-      - 'Type/feat'
+      - 'Release/feat'
   patch:
     labels:
-      - 'Type/fix'
+      - 'Release/fix'
   default: minor
 
 template: |

--- a/.github/workflows/draft-image-release.yml
+++ b/.github/workflows/draft-image-release.yml
@@ -37,7 +37,7 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           gh pr edit ${{ github.event.number }} \
-            --remove-label "Type/break,Type/feat,Type/fix,Type/other"
+            --remove-label "Release/break,Release/feat,Release/fix,Release/other"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -76,7 +76,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.ADMIN_MERGE_TOKEN }}
         run: |
           gh pr create \
-            --label "Type/skip" \
+            --label "Release/skip" \
             --base main \
             --head "${{ github.actor }}/bump-versions-${{ github.sha }}" \
             --title "ci: Bump Helm chart versions" \


### PR DESCRIPTION
# Description
<!-- Describe: (1) what you are doing and (2) why you are doing it -->
- Update labels to make clear they are used for release versioning
- Add field `tag-prefix` to exclude tags created for Helm chart releases

# Checklist
Mandatory:
- [x] PR title is suitable to be included in the release notes

If applicable:
- [x] Changes have been documented
- [x] Changes have been manually tested
- [ ] New tests has been added
