### PR TITLE
fix: Fix 'Release Charts' to avoid error when creating an existing release

### DIFF
--- a/.github/workflows/release-charts.yml
+++ b/.github/workflows/release-charts.yml
@@ -26,3 +26,4 @@ jobs:
         uses: helm/chart-releaser-action@v1.5.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_SKIP_EXISTING: true


### PR DESCRIPTION
# Description
<!-- Describe: (1) what you are doing and (2) why you are doing it -->
When a release already exists, `helm/chart-releaser-action` runs into the following error:
```
Error: error creating GitHub release testbed-0.4.0: POST https://api.github.com/repos/juanjjaramillo/testbed/releases: 422 Validation Failed [{Resource:Release Field:tag_name Code:already_exists Message:}]
```
To cope with this error, we are adding the flag `CR_SKIP_EXISTING: true` to skip releasing existing charts.

# Checklist
Mandatory:
- [x] PR title is suitable to be included in the release notes

If applicable:
- [x] Changes have been documented
- [x] Changes have been manually tested
- [ ] New tests has been added
