### PR TITLE
fix: Fix 'Continuous Integration' workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Docker metadata
+        id: meta
         uses: docker/metadata-action@v5
         with:
           # List of Docker images to use as base name for tags


### PR DESCRIPTION
# Description
<!-- Describe: (1) what you are doing and (2) why you are doing it -->
Missing `id` field in step `Docker metadata` makes fail `Build and push`

# Checklist
Mandatory:
- [x] PR title is suitable to be included in the release notes

If applicable:
- [x] Changes have been documented
- [ ] Changes have been manually tested
- [ ] New tests has been added
