### PR TITLE
feat: Allow Docker image to be pulled

### DIFF
--- a/charts/testbed/values.yaml
+++ b/charts/testbed/values.yaml
@@ -7,7 +7,7 @@ image:
   # -- Overrides image tag (default is chart `appVersion`)
   tag: ""
   # -- Set it to either `IfNotPresent`, `Always` or `Never`
-  pullPolicy: Never
+  pullPolicy: IfNotPresent
 
 # -- Overrides name used in selector labels
 nameOverride: ""


### PR DESCRIPTION
# Description
<!-- Describe: (1) what you are doing and (2) why you are doing it -->
Now that we are pushing images to Docker hub, we can now allow the Helm chart to pull the image if needed

# Checklist
Mandatory:
- [x] PR title is suitable to be included in the release notes

If applicable:
- [ ] Changes have been documented
- [ ] Changes have been manually tested
- [ ] New tests has been added
