### PR TITLE
docs: Improved documentation for 'Continuous Integration' workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
             juanjjaramillo/testbed
           # Generate Docker tags based on the following events/attributes
           tags: |
+            # workflow_dispatch, schedule, push branches events
             # reflects the last commit of the active branch
             type=edge
             # schedule event, nightly tag


### PR DESCRIPTION
# Description
<!-- Describe: (1) what you are doing and (2) why you are doing it -->
Action [docker/metadata-action](https://github.com/docker/metadata-action/tree/v5/) does not have clear documentation on when `edge` tag will be created. Code is documented to keep a record of what events trigger the tag to be created

# Checklist
Mandatory:
- [x] PR title is suitable to be included in the release notes

If applicable:
- [x] Changes have been documented
- [ ] Changes have been manually tested
- [ ] New tests has been added
