### PR TITLE
fix: Allow 'CI' workflow to run when a tag is pushed

### DIFF
--- a/.github/workflows/release-charts.yml
+++ b/.github/workflows/release-charts.yml
@@ -27,3 +27,4 @@ jobs:
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_SKIP_EXISTING: true
+          CR_MAKE_RELEASE_LATEST: false

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -18,13 +18,16 @@ jobs:
 
       - name: Promote draft release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Default GITHUB_TOKEN does not allow to create a new workflow run,
+          # so it does not allow CI pipeline to run when tag is pushed
+          # Source: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
+          GITHUB_TOKEN: ${{ secrets.ADMIN_MERGE_TOKEN }}
         run: |
           echo "$( gh release list --limit 5)"
           tagName=$( gh release list | grep Draft | awk -F' ' '{ print $3; }' )
           if [[ -n "$tagName" ]]; then
             echo "Proceeding to publish release $tagName"
-            gh release edit $tagName --draft=false
+            gh release edit $tagName --draft=false --latest
             echo "tagName=$tagName" >> "$GITHUB_ENV"
           else
             echo "Draft release tag not found. Skipping"


### PR DESCRIPTION
# Description
<!-- Describe: (1) what you are doing and (2) why you are doing it -->
- Default `GITHUB_TOKEN` does not allow to create a new workflow run, so it does not allow CI pipeline to run when tag is pushed. [Source](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow).
- Mark as `latest` image version, not Helm chart version

# Checklist
Mandatory:
- [x] PR title is suitable to be included in the release notes

If applicable:
- [x] Changes have been documented
- [ ] Changes have been manually tested
- [ ] New tests has been added
