### PR TITLE
feat: Make `setup-go` find go version to use by reading `go.mod`

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -43,18 +43,5 @@
       "depNameTemplate": "norwoodj/helm-docs",
       "datasourceTemplate": "github-releases",
     },
-    {
-      "description": "Update Go version",
-      "customType": "regex",
-      "fileMatch": [
-        "(^|/)ci\.ya?ml$",
-      ],
-      "matchStrings": [
-        "\\sGO_VERSION: '(?<currentValue>.*)'\\s"
-      ],
-      "depNameTemplate": "go",
-      "datasourceTemplate": "golang-version",
-      "versioningTemplate": "go-mod-directive",
-    },
   ],
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,6 @@ on:
     branches:
       - 'main'
 
-env:
-  GO_VERSION: '1.20'
-
 jobs:
   lint-charts:
     name: Lint Helm charts
@@ -39,7 +36,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: './go.mod'
 
       - name: Run unit tests for Go
         run: |


### PR DESCRIPTION
# Description
<!-- Describe: (1) what you are doing and (2) why you are doing it -->
Allow `setup-go` figure out which version of Go to use by reading `go.mod`

# Checklist
Mandatory:
- [x] PR title is suitable to be included in the release notes

If applicable:
- [ ] Changes have been documented
- [ ] Changes have been manually tested
- [ ] New tests has been added
