### PR TITLE
fix: Fix typo in 'Publish Release'

### DIFF
--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -50,7 +50,7 @@ jobs:
         # Source: https://tldp.org/LDP/abs/html/parameter-substitution.html
         run: |
           version="v1.11.3"
-          wget https://github.com/norwoodj/helm-docs/releases/download/v${version}/helm-docs_${version}_Linux_x86_64.tar.gz
+          wget https://github.com/norwoodj/helm-docs/releases/download/${version}/helm-docs_${version}_Linux_x86_64.tar.gz
           tar --extract --verbose --file="helm-docs_${version}_Linux_x86_64.tar.gz" helm-docs
           sudo mv helm-docs /usr/local/sbin
 


### PR DESCRIPTION
# Description
<!-- Describe: (1) what you are doing and (2) why you are doing it -->
Fix typo that stops workflow from downloading `helm-docs`

# Checklist
Mandatory:
- [x] PR title is suitable to be included in the release notes

If applicable:
- [ ] Changes have been documented
- [x] Changes have been manually tested
- [ ] New tests has been added
