### PR TITLE
fix: Fix 'Publish Release' by building correct URL

### DIFF
--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -50,7 +50,8 @@ jobs:
         # Source: https://tldp.org/LDP/abs/html/parameter-substitution.html
         run: |
           version="v1.11.3"
-          wget https://github.com/norwoodj/helm-docs/releases/download/${version}/helm-docs_${version}_Linux_x86_64.tar.gz
+          stripped=$( echo "${version}" | sed s'/v//' )
+          wget https://github.com/norwoodj/helm-docs/releases/download/${version}/helm-docs_${stripped}_Linux_x86_64.tar.gz
           tar --extract --verbose --file="helm-docs_${version}_Linux_x86_64.tar.gz" helm-docs
           sudo mv helm-docs /usr/local/sbin
 


### PR DESCRIPTION
# Description
<!-- Describe: (1) what you are doing and (2) why you are doing it -->
URL used to download `helm-docs` has the peculiarity that the tag has syntax `vX.Y.Z` while the file uses `X.Y.Z`

# Checklist
Mandatory:
- [x] PR title is suitable to be included in the release notes

If applicable:
- [ ] Changes have been documented
- [x] Changes have been manually tested
- [ ] New tests has been added
