### PR TITLE
fix: Fix 'Release Version' conditional

### DIFF
--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -12,7 +12,6 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     outputs:
-      releaseAvailable: ${{ steps.promote.outputs.releaseAvailable }}
       tagName: ${{ steps.promote.outputs.tagName }}
     steps:
       # Command `gh release edit` needs to run in a repository,
@@ -37,17 +36,15 @@ jobs:
           if [[ -n "$tagName" ]]; then
             echo "Proceeding to publish release $tagName"
             gh release edit $tagName --draft=false --latest
-            echo "releaseAvailable=true" >> "$GITHUB_OUTPUT"
             echo "tagName=$tagName" >> "$GITHUB_OUTPUT"
           else
             echo "Draft release tag not found. Skipping"
-            echo "releaseAvailable=false" >> "$GITHUB_OUTPUT"
           fi
 
   bump-charts:
     name: Bump Helm chart versions
     needs: [promote-draft-release]
-    if: needs.promote-draft-release.outputs.releaseAvailable
+    if: needs.promote-draft-release.outputs.tagName
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
# Description
<!-- Describe: (1) what you are doing and (2) why you are doing it -->
As explained [here](https://github.com/actions/runner/issues/1483), GitHub Actions treats booleans as strings in contradiction to their documentation. Thus, the safest approach is to assume there are no booleans and use the fact that a null string is casted as a boolean `false`.

# Checklist
Mandatory:
- [x] PR title is suitable to be included in the release notes

If applicable:
- [x] Changes have been documented
- [x] Changes have been manually tested
- [ ] New tests has been added
