### PR TITLE
chore: Pin patch versions in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Build stage: use native architecture and Go's cross-compilation
-FROM --platform=$BUILDPLATFORM golang:1.21@sha256:e63f8cf91f5b59ce217f2804936132b2964b04bb5b06c0a79b9e37990a6ab148 AS build
+FROM --platform=$BUILDPLATFORM golang:1.21.2@sha256:e63f8cf91f5b59ce217f2804936132b2964b04bb5b06c0a79b9e37990a6ab148 AS build
 
 # Set destination for COPY
 WORKDIR /app
@@ -21,7 +21,7 @@ ARG GOARCH=$TARGETARCH
 RUN make build
 
 # Final stage
-FROM alpine:3.18@sha256:25fad2a32ad1f6f510e528448ae1ec69a28ef81916a004d3629874104f8a7f70
+FROM alpine:3.18.2@sha256:25fad2a32ad1f6f510e528448ae1ec69a28ef81916a004d3629874104f8a7f70
 
 WORKDIR /bin
 


### PR DESCRIPTION
# Description
<!-- Describe: (1) what you are doing and (2) why you are doing it -->
Pinning patch versions in Dockerfile achieves two goals:
- It allow humans to translate hash version into a specific semver version
- It forces Renovate to treat hash updates as a 'patch' update type instead of 'dependency', which would break config rules

# Checklist
Mandatory:
- [x] PR title is suitable to be included in the release notes

If applicable:
- [ ] Changes have been documented
- [ ] Changes have been manually tested
- [ ] New tests has been added
