### PR TITLE
fix: Fix 'Release Version' token permissions and `env` variable

### DIFF
--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -49,12 +49,16 @@ jobs:
     name: Bump Helm chart versions
     needs: [promote-draft-release]
     if: needs.promote-draft-release.outputs.tagName
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout GitHub Repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Bump Helm chart versions in `Chart.yaml`
+        env:
+          tagName: ${{ needs.promote-draft-release.outputs.tagName }}
         run: |
           echo "Bumping Helm chart versions to $tagName"
           tagName=$( echo "$tagName" | sed 's/v//' )


### PR DESCRIPTION
# Description
<!-- Describe: (1) what you are doing and (2) why you are doing it -->
- Allow GitHub token to push to a remote branch
- Allow the usage of the environment variable `tagName` in the next job

# Checklist
Mandatory:
- [x] PR title is suitable to be included in the release notes

If applicable:
- [ ] Changes have been documented
- [ ] Changes have been manually tested
- [ ] New tests has been added
